### PR TITLE
Fix nav overflow for mobile devices

### DIFF
--- a/components/nav.rb
+++ b/components/nav.rb
@@ -41,7 +41,7 @@ module Components
 		private
 
 		def nav
-			super(class: "fixed lg:relative w-3/4 border-r-2 border-gray-100 lg:border-0 lg:w-1/4 text-lg lg:text-base h-full z-40 px-10 py-5 -left-full peer-checked:left-0 lg:left-0 bg-white")
+			super(class: "fixed lg:relative w-3/4 border-r-2 border-gray-100 lg:border-0 lg:w-1/4 text-lg lg:text-base h-full z-40 px-10 pt-5 pb-28 sm:pb-5 -left-full peer-checked:left-0 lg:left-0 bg-white overflow-y-scroll")
 		end
 	end
 end


### PR DESCRIPTION
Except on large mobile devices, users are unable to see the bottom items due to an overflow issue. This enables vertical scroll and increases the padding of the nav component.

### Before

https://github.com/joeldrapper/phlex.fun/assets/10230606/92438655-cfdf-4bfa-9309-ad1e89c5f512

### After

https://github.com/joeldrapper/phlex.fun/assets/10230606/d93146a8-f0f0-4aa6-81ac-452e2ea0201b

