### PR TITLE
Update Capybara docs with RSpec example

### DIFF
--- a/pages/testing/capybara.md
+++ b/pages/testing/capybara.md
@@ -16,7 +16,8 @@ gem "phlex-testing-capybara"
 
 ## Usage
 
-You’ll need to require `phlex/testing/capybara` and include `Phlex::Testing::Capybara::ViewHelper`.
+You’ll need to require `phlex/testing/rails/view_helper`, `phlex/testing/capybara` and include `Phlex::Testing::Rails::ViewHelper`, `Phlex::Testing::Capybara::ViewHelper`.
+
 
 The `render` method will return a `Capybara::Node::Simple` and set the `page` attribute to the result.
 
@@ -25,12 +26,54 @@ example do |e|
   e.tab "test.rb", <<~RUBY
     require "phlex/testing/capybara"
 
-    class TestExample < Minitest::Test
+    class TestHello < Minitest::Test
       include Phlex::Testing::Capybara::ViewHelper
 
-      def test_example
-        render Example.new("Joel")
+      def test_hello
+        render Hello.new("Joel")
         assert_selector "h1", text: "Hello Joel"
+      end
+    end
+  RUBY
+
+  e.tab "hello.rb", <<~RUBY
+    class Hello < Phlex::HTML
+      def initialize(name)
+        @name = name
+      end
+
+      def template
+        h1 { "Hello \#{@name}" }
+      end
+    end
+  RUBY
+end
+```
+
+### RSpec
+
+If you're using RSpec you can include the modules for specs marked as `:component` by configuring this in the `spec/rails_helper` or `spec/spec_helper` files.
+
+```phlex
+example do |e|
+  e.tab "spec/rails_helper", <<~RUBY
+    require 'phlex/testing/rails/view_helper'
+    require 'phlex/testing/capybara'
+
+    RSpec.configure do |config|
+      config.include Phlex::Testing::Rails::ViewHelper, type: :component
+      config.include Phlex::Testing::Capybara::ViewHelper, type: :component
+    end
+  RUBY
+	
+  e.tab "hello_spec.rb", <<~RUBY
+    require 'rails_helper'
+
+    RSpec.describe 'Hello', type: :component do
+      it 'renders something' do
+        render(Hello.new("Joel"))
+
+        expect(page).to have_css('h1', text: 'Hello Joel')
       end
     end
   RUBY


### PR DESCRIPTION
This adds an example how to configure RSpec with `phlex-testing-capybara`.

It also
* mentions to include `Phlex::Testing::Rails::ViewHelper` just as in the Nokogiri docs, which was missing before
* updates the test name `TestExample` to `HelloExample` to match the name of the tested `Hello` class