### PR TITLE
Fix attributes keys documentation

### DIFF
--- a/handbook/attributes.md
+++ b/handbook/attributes.md
@@ -24,8 +24,8 @@ h1("data_controller" => "hello") { "Hello!" }
 ```
 
 ```html [output]
-<h1 foo-bar="hello">👋 Hello World!</h1>
-<h1 foo_bar="hello">👋 Hello World!</h1>
+<h1 data-controller="hello">👋 Hello World!</h1>
+<h1 data_controller="hello">👋 Hello World!</h1>
 ```
 
 :::


### PR DESCRIPTION
This PR fixes a minor typo/error in the documentation regarding attribute keys where the input (`data-controller`) didn't match the outputted HTML (`foo-bar`).