### PR TITLE
add missing filename

### DIFF
--- a/handbook/first-component.md
+++ b/handbook/first-component.md
@@ -6,8 +6,8 @@ markup. We’ll use simple classes in our example, but you could imagine if you 
 based CSS framework like Tailwind that you would be abstracting away a lot more.
 
 ```ruby
-# app/views/components/card.rb
-class Card < Phlex::HTML
+# app/components/card.rb
+class Components::Card < Phlex::HTML
   def view_template(&)
     div(class: "card", &)
   end

--- a/handbook/first-component.md
+++ b/handbook/first-component.md
@@ -6,6 +6,7 @@ markup. We’ll use simple classes in our example, but you could imagine if you 
 based CSS framework like Tailwind that you would be abstracting away a lot more.
 
 ```ruby
+# app/views/components/card.rb
 class Card < Phlex::HTML
   def view_template(&)
     div(class: "card", &)


### PR DESCRIPTION
The [first component](https://beta.phlex.fun/handbook/first-component.html) example at the start of the docs doesn’t have a filename. I guessed based on what was added to `condfig/application.rb` but maybe there’s a better path.