### PR TITLE
Fix `Header` example on index.md

### DIFF
--- a/handbook/index.md
+++ b/handbook/index.md
@@ -32,9 +32,9 @@ Now we can use this `Nav` component to build out our menu in our `Header` compon
 class Header < Phlex::HTML
   def view_template
     render Nav.new do |nav|
-      nav.item("/") { "Home "}
-      nav.item("/about") { "About" }
-      nav.item("/contact") { "Contact" }
+      nav.item("Home", "/")
+      nav.item("About", "/about")
+      nav.item("Contact", "/contact")
     end
   end
 end


### PR DESCRIPTION
The example provided didn't actually work. It seems to have been extracted from an earlier example but not update with the changes to the `item` method.