### PR TITLE
Fix `__append_token__` method call in Upgrade guide

### DIFF
--- a/guides/v2-upgrade.md
+++ b/guides/v2-upgrade.md
@@ -59,7 +59,7 @@ end
 
 private
 
-def append_token(tokens, token)
+def __append_token__(tokens, token)
   case token
     when nil then nil
     when String then tokens << token


### PR DESCRIPTION
While upgrading an app to v2 I noticed that the method call in `tokens` is `__append_token__`. I updated the method name to reflect that.

Let me know if you prefer the keep the old method name and I'll update the method calls. 🙌🏼 