### PR TITLE
Mention literal properties next to `grab` helper

### DIFF
--- a/sgml/helpers.md
+++ b/sgml/helpers.md
@@ -140,3 +140,14 @@ end
 ```
 
 :::
+
+::: tip
+
+You’ll probably never need to use `grab` if you use [Literal Properties](/miscellaneous/literal-properties) to generate your initializers, since it automatically escapes reserved keywords by default.
+
+```ruby
+prop :class, String
+prop :if, Proc
+```
+
+:::


### PR DESCRIPTION
I think it makes sense to mention one of the benefits of Literal Properties right next to the `grab` helper.