### PR TITLE
adopt ”smart” quotes globally outside of code

### DIFF
--- a/project/community.md
+++ b/project/community.md
@@ -31,7 +31,7 @@ It’s impossible to know how many people are using Phlex in production, but her
 
 - [Components with Phlex in Rails](https://www.youtube.com/watch?v=l4bQSfqZZfQ)
 - [How I Built It: Calendar UI with Turbo Frames, Tailwind, and Alpine.js](https://www.youtube.com/watch?v=KWA3qCGRP5g&t=1s)
-- [Iterating On Our Calendar UI - "Current Time" Marker](https://www.youtube.com/watch?v=wNnRpmhw_Ks)
+- [Iterating On Our Calendar UI - “Current Time” Marker](https://www.youtube.com/watch?v=wNnRpmhw_Ks)
 
 ## Articles 📝
 


### PR DESCRIPTION
This is a debatable change, since the double quotes appear in a title.  If you prefer to keep the style of double quote that originally appeared in the title on YouTube, then reject this PR.  If you want to use ”smart” quotes anyway, then this is the only place in the docs that I could find ”smart” quotes missing.

It sort of comes down to whether you consider the style of punctuation to be a purely stylistic choice, or whether you consider it to itself be content and therefore preserving it is necessary to accurately represent the original.  

Splitting hairs here, of course, because _everywhere_ else (outside of code) the documentation already had everything ”smartened”.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/phlex-ruby/phlex.fun/pull/70?shareId=b94eea5a-4d0e-4dc0-98a0-4ec93701a3cf).