### PR TITLE
Make difference between helper adapters clearer

### DIFF
--- a/rails/helpers.md
+++ b/rails/helpers.md
@@ -38,6 +38,11 @@ Sometimes you need to register an adapter for your own view helpers, or those pr
 
 ```ruby
 class Components::Base < Phlex::HTML
+  # Register a Rails helper that returns a value that shouldn’t be pushed to the output buffer.
+  # e.g. if you want to use it like `div { format_release_date(book.date) }`
+  register_value_helper :format_release_date
+
+  # Register a Rails helper that returns safe HTML to be pushed to the output buffer.
   register_output_helper :pagy_nav
 end
 ```


### PR DESCRIPTION
Thank you for Phlex, it's really neat!

We're integrating it into a 10+ years old Rails Codebase, and so we have a bunch of helpers already that we can't completely migrate yet. Thankfully, there are the helper adapters!

However, the docs are not really clear when to use which one. I blindly used `register_output_helper` for each one, which wasn't the right call.

For this PR, I mainly copied the comments from https://github.com/phlex-ruby/phlex-rails/blob/f39547c75f4fca59869f99ddb3a58ef1f6659ec4/lib/phlex/rails/helper_macros.rb#L22 and added an example for when you might want `register_value_helper`.

I hope this helps. Thanks again!